### PR TITLE
Add julia 0.4 to REQUIRE

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,1 +1,2 @@
 julia 0.3
+julia 0.4


### PR DESCRIPTION
The README says UnicodePlots is developed for 0.3 and 0.4.  I'd like to try this out on 0.4, but right now Pkg.add("UnicodePlots") doesn't work.