### PR TITLE
Fix histogram range display for large values

### DIFF
--- a/src/interface/histogram.jl
+++ b/src/interface/histogram.jl
@@ -84,8 +84,8 @@ function histogram(v, bins::Int; symb = "▇", args...)
     labels = Array(UTF8String, length(counts))
     binwidth = edges.step / edges.divisor
     @inbounds for i in 1:length(counts)
-        val = float_round_log10(edges[i])
-        labels[i] = string("(", val, ",", float_round_log10(val+binwidth), "]")
+        val = float_round_log10(edges[i], edges.step)
+        labels[i] = string("(", val, ",", float_round_log10(val+binwidth, edges.step), "]")
     end
     barplot(labels, counts; symb = symb, args...)
 end

--- a/test/tst_plots.jl
+++ b/test/tst_plots.jl
@@ -196,6 +196,7 @@ print(myPlot)
 
 print(histogram(rand(1000), bins=10, title="Histogram"))
 print(histogram(rand(1000), title="Histogram"))
+print(histogram(rand(800) * 10000 - 115000, title="Histogram"))
 
 print(spy(sprand(10,10,.15)))
 print(spy(sprand(5,10,.15), width = 5))


### PR DESCRIPTION
When plotting a histogram using some large numbers I noticed that the range of the bins was incorrect:

```julia
julia> histogram(rand(800) * 10000 - 115000, title="Histogram")
                                         Histogram
                         ┌────────────────────────────────────────┐ 
   (-120000.0,-120000.0] │▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇ 64             │ 
   (-110000.0,-110000.0] │▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇ 84      │ 
   (-110000.0,-110000.0] │▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇ 75         │ 
   (-110000.0,-110000.0] │▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇ 85      │ 
   (-110000.0,-110000.0] │▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇ 77         │ 
   (-110000.0,-110000.0] │▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇ 87     │ 
   (-110000.0,-110000.0] │▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇ 69            │ 
   (-110000.0,-110000.0] │▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇ 80        │ 
   (-110000.0,-110000.0] │▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇ 81       │ 
   (-110000.0,-110000.0] │▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇ 98 │ 
                         └────────────────────────────────────────┘ 
```

This PR modifies the code such that the displayed buckets are displayed correctly:
```julia
julia> histogram(rand(800) * 10000 - 115000, title="Histogram")
                                         Histogram
                         ┌────────────────────────────────────────┐ 
   (-115000.0,-114000.0] │▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇ 80    │ 
   (-114000.0,-113000.0] │▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇ 81   │ 
   (-113000.0,-112000.0] │▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇ 84  │ 
   (-112000.0,-111000.0] │▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇ 85  │ 
   (-111000.0,-110000.0] │▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇ 69        │ 
   (-110000.0,-109000.0] │▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇ 76      │ 
   (-109000.0,-108000.0] │▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇ 87 │ 
   (-108000.0,-107000.0] │▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇ 80    │ 
   (-107000.0,-106000.0] │▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇ 79    │ 
   (-106000.0,-105000.0] │▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇ 79    │ 
                         └────────────────────────────────────────┘ 
```
