### PR TITLE
Fix deprecated $, tty_size

### DIFF
--- a/src/graphics/asciicanvas.jl
+++ b/src/graphics/asciicanvas.jl
@@ -75,12 +75,17 @@ ascii_lookup[0b100_100_100] = '|'
 ascii_lookup[0b001_001_001] = '|'
 ascii_lookup[0b110_011_110] = '}'
 
+# julia #18977
+if !isdefined(Base, :⊻)
+    const ⊻ = $
+end
+
 ascii_decode[0b1] = ' '
 for i in 1:511
     min_dist = typemax(Int)
     min_char = ' '
     for (k, v) in ascii_lookup
-        cur_dist = count_ones(UInt16(i) $ k)
+        cur_dist = count_ones(UInt16(i) ⊻ k)
         if cur_dist < min_dist
             min_dist = cur_dist
             min_char = v

--- a/src/interface/spy.jl
+++ b/src/interface/spy.jl
@@ -113,7 +113,7 @@ function spy{T<:Canvas}(
     # if no size bounds ares specified and the session is in an
     # interactive terminal then use the size of the REPL
     if isinteractive()
-        term_height, term_width = Base.tty_size()
+        term_height, term_width = Base.displaysize()
         maxheight = maxheight > 0 ? maxheight : term_height - height_diff
         maxwidth  = maxwidth > 0 ? maxwidth : term_width - width_diff
     else


### PR DESCRIPTION
Fixed deprecated functions,
- WARNING: `x $ y` is deprecated.  use `xor(x, y)` or `x ⊻ y` instead.
- WARNING: tty_size is deprecated. use `displaysize(io)` as a replacement
thanks.