### PR TITLE
Fixes calls to `histogram(...)` with arrays of `Float32`

### DIFF
--- a/src/common.jl
+++ b/src/common.jl
@@ -6,7 +6,7 @@ round_up_tick{F<:AbstractFloat,R<:Real}(x::F,m::R) = x == 0. ? 0.: (x > 0 ? ceil
 round_down_tick{F<:AbstractFloat,R<:Real}(x::F,m::R) = x == 0. ? 0.: (x > 0 ? floor(x, ceil_neg_log10(m)) : -ceil(-x, ceil_neg_log10(m)))
 round_up_subtick{F<:AbstractFloat,R<:Real}(x::F,m::R) = x == 0. ? 0.: (x > 0 ? ceil(x, ceil_neg_log10(m)+1) : -floor(-x, ceil_neg_log10(m)+1))
 round_down_subtick{F<:AbstractFloat,R<:Real}(x::F,m::R) = x == 0. ? 0.: (x > 0 ? floor(x, ceil_neg_log10(m)+1) : -ceil(-x, ceil_neg_log10(m)+1))
-float_round_log10{F<:AbstractFloat,R<:Real}(x::F,m::R) = x == 0. ? 0.: (x > 0 ? round(x, ceil_neg_log10(m)+1)::Float64 : -round(-x, ceil_neg_log10(m)+1)::Float64)
+float_round_log10{F<:AbstractFloat,R<:Real}(x::F,m::R) = x == 0. ? 0.: (x > 0 ? round(x, ceil_neg_log10(m)+1)::F : -round(-x, ceil_neg_log10(m)+1)::F)
 float_round_log10{F<:AbstractFloat}(x::F) = x > 0 ? float_round_log10(x,x) : float_round_log10(x,-x)
 
 function plotting_range{F<:AbstractFloat,R<:AbstractFloat}(xmin::F, xmax::R)

--- a/test/tst_plots.jl
+++ b/test/tst_plots.jl
@@ -199,6 +199,7 @@ print(histogram(rand(1000), bins=5, title="Histogram"))
 print(histogram(rand(1000), title="Histogram"))
 print(histogram(rand(1000)*0.001, title="Histogram"))
 print(histogram(rand(800) * 10000 - 115000, title="Histogram"))
+print(histogram([0.1f0, 0.1f0, 0f0]))
 
 print(spy(sprand(10,10,.15)))
 print(spy(sprand(5,10,.15), width = 5))


### PR DESCRIPTION
`float_round_log10` now returns same float type it was given.

This (at the very least) fixes calls to `histogram(...)` with arrays of `Float32`: previously, calling `histogram` with an array of `Float32` would crash with:
```jl
ERROR: LoadError: TypeError: float_round_log10: in typeassert, expected Float64, got Float32
```