### PR TITLE
implemented arbitrary scale transformations for barplots

### DIFF
--- a/src/UnicodePlots.jl
+++ b/src/UnicodePlots.jl
@@ -13,7 +13,10 @@ export
             BlockCanvas,
             AsciiCanvas,
             DotCanvas,
-        BarplotGraphics,
+        BarplotGraphicsArea,
+            BarplotGraphics,
+            BarplotTransform,
+            barplotgraphics,
 
     pixel_width,
     pixel_height,

--- a/src/graphics/bargraphics.jl
+++ b/src/graphics/bargraphics.jl
@@ -1,4 +1,6 @@
-mutable struct BarplotGraphics{R<:Number} <: GraphicsArea
+abstract type BarplotGraphicsArea <: GraphicsArea end
+
+mutable struct BarplotGraphics{R<:Number} <: BarplotGraphicsArea
     bars::Vector{R}
     color::Symbol
     width::Int
@@ -18,8 +20,18 @@ mutable struct BarplotGraphics{R<:Number} <: GraphicsArea
     end
 end
 
+mutable struct BarplotTransform{R′<:Number,R<:Number,T<:Function} <: BarplotGraphicsArea
+    graphics::BarplotGraphics{R}
+    bars′::Vector{R′}
+    max_freq′::R′
+    transform::T
+end
+
 nrows(c::BarplotGraphics) = length(c.bars)
 ncols(c::BarplotGraphics) = c.width
+
+nrows(c::BarplotTransform) = length(c.graphics.bars)
+ncols(c::BarplotTransform) = c.graphics.width
 
 function BarplotGraphics(
         bars::AbstractVector{R},
@@ -29,10 +41,51 @@ function BarplotGraphics(
     BarplotGraphics{R}(bars, width, color, symb)
 end
 
+function BarplotTransform(
+        bars::AbstractVector{R},
+        width::Int,
+        transform::T;
+        color::Symbol = :blue,
+        symb::String = "▪") where {R <: Number, T <: Function}
+    g = BarplotGraphics(bars, width, color=color, symb=symb)
+    bars′ = transform.(bars)
+    max_freq′ = transform(g.max_freq)
+    BarplotTransform{eltype(bars′),R,T}(g, bars′, max_freq′, transform)
+end
+
+function barplotgraphics(bars::AbstractVector,
+                         width::Int,
+                         ::typeof(identity);
+                         color::Symbol = :blue,
+                         symb::String = "▪")
+    BarplotGraphics(bars, width, color=color, symb=symb)
+end
+function barplotgraphics(bars::AbstractVector,
+                         width::Int,
+                         transform::Function;
+                         color::Symbol = :blue,
+                         symb::String = "▪")
+    BarplotTransform(bars, width, transform, color=color, symb=symb)
+end
+function barplotgraphics(bars::AbstractVector,
+                         width::Int;
+                         transform::Function=identity,
+                         color::Symbol = :blue,
+                         symb::String = "▪")
+    barplotgraphics(bars, width, transform, color=color, symb=symb)
+end
+
 function addrow!(c::BarplotGraphics{R}, bars::AbstractVector{R}) where {R <: Number}
     append!(c.bars, bars)
     c.max_freq = maximum(c.bars)
     c.max_len = length(string(c.max_freq))
+    c
+end
+function addrow!(c::BarplotTransform{R′,R}, bars::AbstractVector{R}
+                ) where {R′ <: Number, R <: Number}
+    addrow!(c.graphics, bars)
+    append!(c.bars′, c.transform.(bars))
+    c.max_freq′ = maximum(c.bars′)
     c
 end
 
@@ -40,6 +93,12 @@ function addrow!(c::BarplotGraphics{R}, bar::Number) where {R <: Number}
     push!(c.bars, R(bar))
     c.max_freq = max(c.max_freq, R(bar))
     c.max_len = length(string(c.max_freq))
+    c
+end
+function addrow!(c::BarplotTransform{R′,R}, bar::Number) where {R′ <: Number, R <: Number}
+    addrow!(c.graphics, bar)
+    push!(c.bars′, R′(bar))
+    c.max_freq′ = max(c.max_freq′, R′(bar))
     c
 end
 
@@ -53,6 +112,20 @@ function printrow(io::IO, c::BarplotGraphics, row::Int)
     printstyled(io, bar_str; color = c.color)
     printstyled(io, " ", bar_lbl; color = :white)
     pan_len = max(max_bar_width + 1 + c.max_len - bar_len - length(bar_lbl), 0)
+    pad = repeat(" ", round(Int, pan_len))
+    print(io, pad)
+end
+function printrow(io::IO, c::BarplotTransform, row::Int)
+    0 < row <= nrows(c) || throw(ArgumentError("Argument row out of bounds: $row"))
+    bar′ = c.bars′[row]
+    bar = c.graphics.bars[row]
+    max_bar_width = max(c.graphics.width - 2 - c.graphics.max_len, 1)
+    bar_len = c.max_freq′ > 0 ? round(Int, bar′/c.max_freq′ * max_bar_width, RoundNearestTiesUp) : 0
+    bar_str = c.max_freq′ > 0 ? repeat(c.graphics.symb, bar_len) : ""
+    bar_lbl = string(bar)
+    printstyled(io, bar_str; color = c.graphics.color)
+    printstyled(io, " ", bar_lbl; color = :white)
+    pan_len = max(max_bar_width + 1 + c.graphics.max_len - bar_len - length(bar_lbl), 0)
     pad = repeat(" ", round(Int, pan_len))
     print(io, pad)
 end

--- a/src/interface/barplot.jl
+++ b/src/interface/barplot.jl
@@ -86,13 +86,14 @@ function barplot(
         color::Symbol = :blue,
         width::Int = 40,
         labels::Bool = true,
-        symb = "▪")
+        symb = "▪",
+        transform::Function=identity)
     margin >= 0 || throw(ArgumentError("Margin must be greater than or equal to 0"))
     length(text) == length(heights) || throw(DimensionMismatch("The given vectors must be of the same length"))
     minimum(heights) >= 0 || throw(ArgumentError("All values have to be positive. Negative bars are not supported."))
     width = max(width, 5)
 
-    area = BarplotGraphics(heights, width, color = color, symb = symb)
+    area = barplotgraphics(heights, width, transform=transform, color=color, symb=symb)
     new_plot = Plot(area, title = title, margin = margin,
                    padding = padding, border = border, labels = labels)
     for i in 1:length(text)


### PR DESCRIPTION
This implements arbitrary scale transformations for the ordinate of bar plots (including histograms).  I did this because, though I love this package, the inability to make log plots was severely limiting its usefulness for me.

Obviously there are all sorts of features regarding scale transformations which would be nice to have which I have still not implemented.  I really did not go too crazy here, but my hope is that what's here will nevertheless be a good starting point and provide a sorely needed basic functionality for some simple use cases.  Of course, it was already possible to implement some simple transformations by doing, e.g. `barplot(labels, log10.(x))`, but with this PR it is possible to do this while retaining the original (untransformed) labels.  For example:
```julia
julia> histogram(randn(10^5), transform=log10)
               ┌────────────────────────────────────────┐ 
   (-4.5,-4.0] │ 1                                      │ 
   (-4.0,-3.5] │▇▇▇▇▇▇▇▇ 12                             │ 
   (-3.5,-3.0] │▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇ 101                     │ 
   (-3.0,-2.5] │▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇ 488               │ 
   (-2.5,-2.0] │▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇ 1624          │ 
   (-2.0,-1.5] │▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇ 4375       │ 
   (-1.5,-1.0] │▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇ 9298    │ 
   (-1.0,-0.5] │▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇ 14910  │ 
    (-0.5,0.0] │▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇ 19116 │ 
     (0.0,0.5] │▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇ 19292 │ 
     (0.5,1.0] │▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇ 14963  │ 
     (1.0,1.5] │▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇ 9106     │ 
     (1.5,2.0] │▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇ 4433       │ 
     (2.0,2.5] │▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇ 1672          │ 
     (2.5,3.0] │▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇ 457                │ 
     (3.0,3.5] │▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇ 127                    │ 
     (3.5,4.0] │▇▇▇▇▇▇▇▇▇▇ 22                           │ 
     (4.0,4.5] │▇▇▇▇ 3                                  │ 
               └────────────────────────────────────────┘ 
```
This PR is of course a little elaborate for providing that ability alone, but again, my hope is that it can be used as a starting point to add more features at least for barplots.

If you approve and are interested in merging this, I suggest we leave the first PR pretty simple and if we do more, save it for future updates.  Thanks!