### PR TITLE
Add box-and-whisker plots

### DIFF
--- a/src/UnicodePlots.jl
+++ b/src/UnicodePlots.jl
@@ -14,6 +14,7 @@ export
             AsciiCanvas,
             DotCanvas,
         BarplotGraphics,
+        BoxplotGraphics,
 
     pixel_width,
     pixel_height,
@@ -44,7 +45,8 @@ export
     stairs, stairs!,
     histogram,
     densityplot, densityplot!,
-    spy
+    spy,
+    boxplot
 
 include("common.jl")
 include("canvas.jl")
@@ -55,6 +57,7 @@ include("graphics/blockcanvas.jl")
 include("graphics/asciicanvas.jl")
 include("graphics/dotcanvas.jl")
 include("graphics/bargraphics.jl")
+include("graphics/boxgraphics.jl")
 include("plot.jl")
 include("interface/barplot.jl")
 include("interface/histogram.jl")
@@ -63,5 +66,6 @@ include("interface/lineplot.jl")
 include("interface/stairs.jl")
 include("interface/densityplot.jl")
 include("interface/spy.jl")
+include("interface/boxplot.jl")
 
 end

--- a/src/UnicodePlots.jl
+++ b/src/UnicodePlots.jl
@@ -46,7 +46,7 @@ export
     histogram,
     densityplot, densityplot!,
     spy,
-    boxplot
+    boxplot, boxplot!
 
 include("common.jl")
 include("canvas.jl")

--- a/src/graphics/boxgraphics.jl
+++ b/src/graphics/boxgraphics.jl
@@ -1,0 +1,89 @@
+using StatsBase
+
+struct FiveNumberSummary
+    minimum::Float64
+    lower_quartile::Float64
+    median::Float64
+    upper_quartile::Float64
+    maximum::Float64
+end
+
+mutable struct BoxplotGraphics{R<:Number} <: GraphicsArea
+    data::Vector{FiveNumberSummary}
+    color::Symbol
+    width::Int
+    left::R
+    right::R
+
+    function BoxplotGraphics{R}(
+            data::AbstractVector{R},
+            width::Int,
+            color::Symbol,
+            left::R,
+            right::R) where R
+        width = max(width, 10)
+        new{R}(
+            [FiveNumberSummary(
+                min(data...),
+                percentile(data, 25),
+                percentile(data, 50),
+                percentile(data, 75),
+                max(data...)
+            )], color, width, left, right)
+    end
+end
+
+nrows(c::BoxplotGraphics) = 3*length(c.data)
+ncols(c::BoxplotGraphics) = c.width
+
+function BoxplotGraphics(
+        data::AbstractVector{R},
+        width::Int;
+        color::Symbol = :blue,
+        left::R,
+        right::R) where {R <: Number}
+    BoxplotGraphics{R}(data, width, color, left, right)
+end
+
+function printrow(io::IO, c::BoxplotGraphics, row::Int)
+    0 < row <= nrows(c) || throw(ArgumentError("Argument row out of bounds: $row"))
+    series = c.data[Int(ceil(row/3))]
+
+    transform = value -> Int(round((value - c.left)/(c.right - c.left) * c.width))
+
+    seriesRow = Int(row-1 % 3) + 1
+
+    minChar = ['│', '├' , '│'][seriesRow]
+    lineChar = [' ', '─' , ' '][seriesRow]
+    leftBoxChar = ['┌', '┤' , '└'][seriesRow]
+    lineBoxChar = ['─', ' ' , '─'][seriesRow]
+    medianChar = ['┬', '│' , '┴'][seriesRow]
+    rightBoxChar = ['┐', '├' , '┘'][seriesRow]
+    maxChar = ['│', '┤' , '│'][seriesRow]
+
+    line = [' ' for _ in 1:c.width]
+
+    # Draw points first - this is most important, so they'll always be drawn
+    # even if there's not enough space
+    line[transform(series.minimum)] = minChar
+    line[transform(series.lower_quartile)] = leftBoxChar
+    line[transform(series.median)] = medianChar
+    line[transform(series.upper_quartile)] = rightBoxChar
+    line[transform(series.maximum)] = maxChar
+
+    # Fill in gaps with lines
+    for i in transform(series.minimum)+1:transform(series.lower_quartile)-1
+        line[i] = lineChar
+    end
+    for i in transform(series.lower_quartile)+1:transform(series.median)-1
+        line[i] = lineBoxChar
+    end
+    for i in transform(series.median)+1:transform(series.upper_quartile)-1
+        line[i] = lineBoxChar
+    end
+    for i in transform(series.upper_quartile)+1:transform(series.maximum)-1
+        line[i] = lineChar
+    end
+
+    printstyled(io, join(line), color = c.color)
+end

--- a/src/graphics/boxgraphics.jl
+++ b/src/graphics/boxgraphics.jl
@@ -41,8 +41,19 @@ function BoxplotGraphics(
         width::Int;
         color::Symbol = :blue,
         left::R,
-        right::R) where {R <: Number}
+        right::R,
+        labels::AbstractVector{<:AbstractString} = []) where {R <: Number}
     BoxplotGraphics{R}(data, width, color, left, right)
+end
+
+function addseries!(c::BoxplotGraphics, data::AbstractVector{R}) where {R <: Number}
+    append!(c.data, [FiveNumberSummary(
+        min(data...),
+        percentile(data, 25),
+        percentile(data, 50),
+        percentile(data, 75),
+        max(data...)
+    )])
 end
 
 function printrow(io::IO, c::BoxplotGraphics, row::Int)
@@ -51,7 +62,7 @@ function printrow(io::IO, c::BoxplotGraphics, row::Int)
 
     transform = value -> Int(round((value - c.left)/(c.right - c.left) * c.width))
 
-    seriesRow = Int(row-1 % 3) + 1
+    seriesRow = Int((row-1) % 3) + 1
 
     minChar = ['│', '├' , '│'][seriesRow]
     lineChar = [' ', '─' , ' '][seriesRow]

--- a/src/graphics/boxgraphics.jl
+++ b/src/graphics/boxgraphics.jl
@@ -24,11 +24,11 @@ mutable struct BoxplotGraphics{R<:Number} <: GraphicsArea
         width = max(width, 10)
         new{R}(
             [FiveNumberSummary(
-                min(data...),
+                minimum(data),
                 percentile(data, 25),
                 percentile(data, 50),
                 percentile(data, 75),
-                max(data...)
+                maximum(data)
             )], color, width, left, right)
     end
 end
@@ -48,11 +48,11 @@ end
 
 function addseries!(c::BoxplotGraphics, data::AbstractVector{R}) where {R <: Number}
     append!(c.data, [FiveNumberSummary(
-        min(data...),
+        minimum(data),
         percentile(data, 25),
         percentile(data, 50),
         percentile(data, 75),
-        max(data...)
+        maximum(data)
     )])
 end
 

--- a/src/interface/boxplot.jl
+++ b/src/interface/boxplot.jl
@@ -27,16 +27,16 @@ Arguments
 ==========
 
 - **`data`** : The data the box plot is based on. A vector of vectors, with each
-inner vector representing a data series. Choose a vector of vectors over a matrix
-to allow series of different lengths.
+  inner vector representing a data series. Choose a vector of vectors over a matrix
+  to allow series of different lengths.
 
 - **`labels`** : A list of labels for the data series. Must be the same length as the number of series.
 
 - **`dictionary`** : A dictonary in which the keys will be used as `labels`
-and the values will be utilized as `data`.
+  and the values will be utilized as `data`.
 
 - **`border`** : The style of the bounding box of the plot.
-Supports `:solid`, `:bold`, `:dashed`, `:dotted`, `:ascii`, and `:none`.
+  Supports `:solid`, `:bold`, `:dashed`, `:dotted`, `:ascii`, and `:none`.
 
 - **`title`** : Text to display on the top of the plot.
 
@@ -45,8 +45,8 @@ Supports `:solid`, `:bold`, `:dashed`, `:dotted`, `:ascii`, and `:none`.
 - **`padding`** : Space of the left and right of the plot between the labels and the canvas.
 
 - **`color`** : Colour of the drawing. Can be any of `:black`, `:blue`, `:cyan`,
-`:green`, `:magenta`, `:red`, `:yellow`, `:white`, or a light version of the above (`:light_colour`).
-By default no colouring is applied.
+  `:green`, `:magenta`, `:red`, `:yellow`, `:white`, or a light version of the above (`:light_colour`).
+  By default no colouring is applied.
 
 - **`width`** : Number of characters per row that should be used for plotting.
 
@@ -115,10 +115,9 @@ function boxplot(
     annotate!(new_plot, :b, string((left + right) / 2))
     annotate!(new_plot, :br, string(right))
 
-    for label in labels
-        annotate!(new_plot, :l, "   ")
-        annotate!(new_plot, :l, label)
-        annotate!(new_plot, :l, "   ")
+    for (i, label) in enumerate(labels)
+        # Find end of last 3-line region, then add 2 for centre of current
+        annotate!(new_plot, :l, (i-1)*3+2, label)
     end
 
     new_plot
@@ -148,9 +147,8 @@ function boxplot!(
 
     addseries!(plot.graphics, data)
 
-    annotate!(plot, :l, "   ")
-    annotate!(plot, :l, label)
-    annotate!(plot, :l, "   ")
+    # Find end of last 3-line region, then add 2 for centre of current
+    annotate!(plot, :l, (length(plot.graphics.data)-1)*3+2, label)
 
     annotate!(plot, :bl, string(plot.graphics.left))
     annotate!(plot, :b, string((plot.graphics.left + plot.graphics.right) / 2))

--- a/src/interface/boxplot.jl
+++ b/src/interface/boxplot.jl
@@ -1,0 +1,100 @@
+"""
+`boxplot(data; nargs...)` → `Plot`
+
+Description
+============
+
+Draws a box-and-whisker plot.
+The first argument specifies the one dimensional vector of data to plot.
+Alternatively, one can specify a boxplot using a dictionary.
+In that case, the values, which have to be numeric, will be used as the data.
+
+
+Usage
+======
+
+    boxplot(data; border = :solid, title = "", margin = 3, padding = 1, color = :blue, width = 40)
+
+    boxplot(dictionary; nargs...)
+
+Arguments
+==========
+
+- **`data`** : The 1-D vector of data the box plot is based on
+
+- **`dictionary`** : A dictonary in which the keys will be used as `text`
+and the values will be utilized as `heights`.
+
+- **`border`** : The style of the bounding box of the plot.
+Supports `:solid`, `:bold`, `:dashed`, `:dotted`, `:ascii`, and `:none`.
+
+- **`title`** : Text to display on the top of the plot.
+
+- **`margin`** : Number of empty characters to the left of the whole plot.
+
+- **`padding`** : Space to the left and right of the plot.
+
+- **`color`** : Colour of the drawing. Can be any of `:black`, `:blue`, `:cyan`,
+`:green`, `:magenta`, `:red`, `:yellow`, `:white`, or a light version of the above (`:light_colour`).
+By default no colouring is applied.
+
+- **`width`** : Number of characters per row that should be used for plotting.
+
+Returns
+========
+
+A plot object of type `Plot{BoxplotGraphics}`
+
+Author(s)
+==========
+
+- Matthew Lake (Github: https://github.com/mgtlake)
+
+Examples
+=========
+
+    julia> boxplot([1, 2, 3, 7], title = "Test")
+
+                       Test
+     ┌────────────────────────────────────────┐
+     │    │   ┌──┬───────┐              │     │
+     │    ├───┤  │       ├──────────────┤     │
+     │    │   └──┴───────┘              │     │
+     └────────────────────────────────────────┘
+     0                  4.0                   8
+
+See also
+=========
+
+`Plot`, `histogram`, `BoxplotGraphics`
+"""
+function boxplot(
+        data::AbstractVector{<:Number};
+        border = :solid,
+        title::AbstractString = "",
+        margin::Int = 4,
+        padding::Int = 0,
+        color::Symbol = :normal,
+        width::Int = 40,
+        left::Number = min(data...) - 1,
+        right::Number = max(data...) + 1)
+    margin >= 0 || throw(ArgumentError("Margin must be greater than or equal to 0"))
+    width = max(width, 10)
+
+    if left > min(data...) || right < max(data...)
+        throw(ArgumentError("Plot range ($left, $right) too restrictive for data range ($(min(data...)), $(max(data...)))"))
+    end
+
+    area = BoxplotGraphics(data, width, color = color, left = left, right = right)
+    new_plot = Plot(area, title = title, margin = margin,
+                   padding = padding, border = border)
+
+    annotate!(new_plot, :bl, string(left))
+    annotate!(new_plot, :b, string((left + right) / 2))
+    annotate!(new_plot, :br, string(right))
+    new_plot
+end
+
+function boxplot(dict::Dict{T,N}; kw...) where {T, N <: Number}
+    boxplot(collect(values(dict)); kw...)
+end

--- a/src/interface/boxplot.jl
+++ b/src/interface/boxplot.jl
@@ -17,7 +17,7 @@ and the keys, which have to be strings, will be used as the labels.
 Usage
 ======
 
-    boxplot(data; labels = ["" for _ in 1:size(data, 1)], border = :solid, title = "",
+    boxplot(data; labels = [" " for _ in 1:size(data, 1)], border = :solid, title = "",
             margin = 3, padding = 1, color = :blue, width = 40,
             left=minimum(map(minimum, data)) - 1, right=maximum(map(maximum, data)) + 1)
 
@@ -84,7 +84,7 @@ See also
 """
 function boxplot(
         data::AbstractVector;
-        labels::AbstractVector{<:AbstractString} = ["" for _ in 1:size(data, 1)],
+        labels::AbstractVector{<:AbstractString} = [" " for _ in 1:size(data, 1)],
         border = :solid,
         title::AbstractString = "",
         margin::Int = 3,

--- a/test/tst_plots.jl
+++ b/test/tst_plots.jl
@@ -250,7 +250,7 @@ print(boxplot([1,2,3,4,5], right=15, title="Resize properly"))
 print(boxplot([1,2,3,4,5], right=20, title="Resize properly"))
 
 
-plot = boxplot([[1,2,3,4,5], [2,3,4,5,6,7,8,9]], title="Multi-series")
+plot = boxplot([[1,2,3,4,5], [2,3,4,5,6,7,8,9]], title="Multi-series", labels=["one", "two"])
 print(plot)
 
 print(boxplot!(plot, [-1,2,3,4,11], label="One more"))

--- a/test/tst_plots.jl
+++ b/test/tst_plots.jl
@@ -241,3 +241,16 @@ print(lineplot(d,v, height = 5))
 miny = -1.2796649117521434e218
 maxy = -miny
 println(scatterplot([1],[miny],xlim=[1,1],ylim=[miny,maxy],title="Don't you crash on me!"))
+
+print(boxplot([1,2,3,4,5], title="Test", left=-1, right=8, color=:blue, width=40, labels=["series1"]))
+print(boxplot([1,2,3,4,5], right=5, title="Resize properly"))
+print(boxplot([1,2,3,4,5], right=6, title="Resize properly"))
+print(boxplot([1,2,3,4,5], right=10, title="Resize properly"))
+print(boxplot([1,2,3,4,5], right=15, title="Resize properly"))
+print(boxplot([1,2,3,4,5], right=20, title="Resize properly"))
+
+
+plot = boxplot([[1,2,3,4,5], [2,3,4,5,6,7,8,9]], title="Multi-series")
+print(plot)
+
+print(boxplot!(plot, [-1,2,3,4,11], label="One more"))


### PR DESCRIPTION
Addresses #13 - currently only supports horizontal plots (my preference), but vertical box plot support could be added down the line.

It is a known limitation that if the scale is set too high, only some of the features of the box plot will not be drawn. This is not considered important since a text-based display can only draw so much detail in any case.

Example of a box plot with multiple data series:
```
                          Multi-series
            ┌────────────────────────────────────────┐ 
            │        │ ┌──┬──┐  │                    │ 
            │        ├─┤  │  ├──┤                    │ 
            │        │ └──┴──┘  │                    │ 
            │          │    ┌────┬────┐    │         │ 
            │          ├────┤    │    ├────┤         │ 
            │          │    └────┴────┘    │         │ 
            │  │       ┌──┬──┐                   │   │ 
   One more │  ├───────┤  │  ├───────────────────┤   │ 
            │  │       └──┴──┘                   │   │ 
            └────────────────────────────────────────┘ 
            -2                 5.0                  12
```