### PR TITLE
Add tuple support for xlim and ylim

### DIFF
--- a/src/common.jl
+++ b/src/common.jl
@@ -68,7 +68,7 @@ function extend_limits(vec, limits)
         ma = mi + 1
         mi = mi - 1
     end
-    (limits == [0.,0.]) ? plotting_range_narrow(mi, ma) : (mi, ma)
+    (limits == (0.,0.) || limits == [0.,0.]) ? plotting_range_narrow(mi, ma) : (mi, ma)
 end
 
 const bordermap = Dict{Symbol,Dict{Symbol,String}}()

--- a/src/interface/boxplot.jl
+++ b/src/interface/boxplot.jl
@@ -39,6 +39,9 @@ Arguments
 
 $DOC_PLOT_PARAMS
 
+- **`xlim`** : Plotting range for the data axis.
+  `(0, 0)` stands for automatic.
+
 Returns
 ========
 
@@ -74,9 +77,9 @@ function boxplot(
         border = :corners,
         color::Symbol = :green,
         width::Int = 40,
-        xlim::AbstractVector = [0., 0.],
+        xlim = (0., 0.),
         kw...)
-    length(xlim) == 2 || throw(ArgumentError("xlim must only be vectors of length 2"))
+    length(xlim) == 2 || throw(ArgumentError("xlim must be a tuple or a vector of length 2"))
     length(text) == length(data) || throw(DimensionMismatch("Wrong number of text"))
     min_x, max_x = extend_limits(reduce(vcat, data), xlim)
     width = max(width, 10)
@@ -117,7 +120,6 @@ function boxplot!(
         plot::Plot{<:BoxplotGraphics},
         data::AbstractVector{<:Number};
         name = " ",
-        xlim::AbstractVector = [0., 0.],
         kw...)
     !isempty(data)|| throw(ArgumentError("Can't append empty array to boxplot"))
 

--- a/src/interface/densityplot.jl
+++ b/src/interface/densityplot.jl
@@ -15,7 +15,7 @@ ordering.
 Usage
 ======
 
-    densityplot(x, y; name = "", title = "", xlabel = "", ylabel = "", labels = true, border = :solid, margin = 3, padding = 1, color = :auto, width = 40, height = 15, xlim = [0, 0], ylim = [0, 0], ^grid = false)
+    densityplot(x, y; name = "", title = "", xlabel = "", ylabel = "", labels = true, border = :solid, margin = 3, padding = 1, color = :auto, width = 40, height = 15, xlim = (0, 0), ylim = (0, 0), grid = false)
 
 Arguments
 ==========
@@ -34,10 +34,10 @@ $DOC_PLOT_PARAMS
   for plotting.
 
 - **`xlim`** : Plotting range for the x axis.
-  `[0, 0]` stands for automatic.
+  `(0, 0)` stands for automatic.
 
 - **`ylim`** : Plotting range for the y axis.
-  `[0, 0]` stands for automatic.
+  `(0, 0)` stands for automatic.
 
 - **`grid`** : If `true`, draws grid-lines at the origin.
 

--- a/src/interface/lineplot.jl
+++ b/src/interface/lineplot.jl
@@ -15,7 +15,7 @@ length and ordering.
 Usage
 ======
 
-    lineplot([x], y; name = "", title = "", xlabel = "", ylabel = "", labels = true, border = :solid, margin = 3, padding = 1, color = :auto, width = 40, height = 15, xlim = [0, 0], ylim = [0, 0], canvas = BrailleCanvas, grid = true)
+    lineplot([x], y; name = "", title = "", xlabel = "", ylabel = "", labels = true, border = :solid, margin = 3, padding = 1, color = :auto, width = 40, height = 15, xlim = (0, 0), ylim = (0, 0), canvas = BrailleCanvas, grid = true)
 
     lineplot(fun, [start], [stop]; kwargs...)
 
@@ -41,10 +41,10 @@ $DOC_PLOT_PARAMS
   for plotting.
 
 - **`xlim`** : Plotting range for the x axis.
-  `[0, 0]` stands for automatic.
+  `(0, 0)` stands for automatic.
 
 - **`ylim`** : Plotting range for the y axis.
-  `[0, 0]` stands for automatic.
+  `(0, 0)` stands for automatic.
 
 - **`canvas`** : The type of canvas that should be used for drawing.
 
@@ -129,7 +129,7 @@ end
 function lineplot(
         x::AbstractVector{<:TimeType},
         y::AbstractVector;
-        xlim = [extrema(Dates.value.(x))...],
+        xlim = extrema(Dates.value.(x)),
         kw...)
     d = Dates.value.(x)
     new_plot = lineplot(d, y; xlim = xlim, kw...)

--- a/src/interface/scatterplot.jl
+++ b/src/interface/scatterplot.jl
@@ -15,7 +15,7 @@ ordering.
 Usage
 ======
 
-    scatterplot([x], y; name = "", title = "", xlabel = "", ylabel = "", labels = true, border = :solid, margin = 3, padding = 1, color = :auto, width = 40, height = 15, xlim = [0, 0], ylim = [0, 0], canvas = BrailleCanvas, grid = true)
+    scatterplot([x], y; name = "", title = "", xlabel = "", ylabel = "", labels = true, border = :solid, margin = 3, padding = 1, color = :auto, width = 40, height = 15, xlim = (0, 0), ylim = (0, 0), canvas = BrailleCanvas, grid = true)
 
 Arguments
 ==========
@@ -34,10 +34,10 @@ $DOC_PLOT_PARAMS
   for plotting.
 
 - **`xlim`** : Plotting range for the x axis.
-  `[0, 0]` stands for automatic.
+  `(0, 0)` stands for automatic.
 
 - **`ylim`** : Plotting range for the y axis.
-  `[0, 0]` stands for automatic.
+  `(0, 0)` stands for automatic.
 
 - **`canvas`** : The type of canvas that should be used for drawing.
 

--- a/src/interface/stairs.jl
+++ b/src/interface/stairs.jl
@@ -15,7 +15,7 @@ ordering.
 Usage
 ======
 
-    stairs(x, y; style = :post, name = "", title = "", xlabel = "", ylabel = "", labels = true, border = :solid, margin = 3, padding = 1, color = :auto, width = 40, height = 15, xlim = [0, 0], ylim = [0, 0], canvas = BrailleCanvas, grid = true)
+    stairs(x, y; style = :post, name = "", title = "", xlabel = "", ylabel = "", labels = true, border = :solid, margin = 3, padding = 1, color = :auto, width = 40, height = 15, xlim = (0, 0), ylim = (0, 0), canvas = BrailleCanvas, grid = true)
 
 Arguments
 ==========
@@ -36,10 +36,10 @@ $DOC_PLOT_PARAMS
   for plotting.
 
 - **`xlim`** : Plotting range for the x axis.
-  `[0, 0]` stands for automatic.
+  `(0, 0)` stands for automatic.
 
 - **`ylim`** : Plotting range for the y axis.
-  `[0, 0]` stands for automatic.
+  `(0, 0)` stands for automatic.
 
 - **`canvas`** : The type of canvas that should be used for drawing.
 

--- a/src/plot.jl
+++ b/src/plot.jl
@@ -13,7 +13,7 @@ Usage
 
     Plot(graphics; title = "", xlabel = "", ylabel = "", border = :solid, margin = 3, padding = 1, labels = true)
 
-    Plot(x, y, canvastype; title = "", xlabel = "", ylabel = "", width = 40, height = 15, border = :solid, xlim = [0, 0], ylim = [0, 0], margin = 3, padding = 1, labels = true, grid = true)
+    Plot(x, y, canvastype; title = "", xlabel = "", ylabel = "", width = 40, height = 15, border = :solid, xlim = (0, 0), ylim = (0, 0), margin = 3, padding = 1, labels = true, grid = true)
 
 Arguments
 ==========
@@ -118,13 +118,13 @@ function Plot(
         width::Int = 40,
         height::Int = 15,
         border::Symbol = :solid,
-        xlim::AbstractVector = [0.,0.],
-        ylim::AbstractVector = [0.,0.],
+        xlim = (0.,0.),
+        ylim = (0.,0.),
         margin::Int = 3,
         padding::Int = 1,
         labels::Bool = true,
         grid::Bool = true) where {C<:Canvas}
-    length(xlim) == length(ylim) == 2 || throw(ArgumentError("xlim and ylim must only be vectors of length 2"))
+    length(xlim) == length(ylim) == 2 || throw(ArgumentError("xlim and ylim must be tuples or vectors of length 2"))
     length(X) == length(Y) || throw(DimensionMismatch("X and Y must be the same length"))
     width = max(width, 5)
     height = max(height, 2)

--- a/src/plot.jl
+++ b/src/plot.jl
@@ -1,5 +1,5 @@
 """
-`Plot(graphics; nargs...)` → `Plot`
+    Plot(graphics; nargs...)
 
 Description
 ============
@@ -18,37 +18,28 @@ Usage
 Arguments
 ==========
 
-- **`graphics`** : The `GraphicsArea` (e.g. a subtype of `Canvas`) that the plot should decorate
+- **`graphics`** : The `GraphicsArea` (e.g. a subtype of
+  `Canvas`) that the plot should decorate.
 
-- **`x`** : The horizontal dimension for each point.
+- **`x`** : The horizontal position for each point.
 
-- **`y`** : The vertical dimension for each point.
+- **`y`** : The vertical position for each point.
 
-- **`canvastype`** : The type of canvas that should be used for drawing.
+- **`canvastype`** : The type of canvas that should be used for
+  drawing.
 
-- **`title`** : Text to display on the top of the plot.
+$DOC_PLOT_PARAMS
 
-- **`xlabel`** : Text to display on the x axis of the plot
+- **`height`** : Number of character rows that should be used
+  for plotting.
 
-- **`ylabel`** : Text to display on the y axis of the plot
+- **`xlim`** : Plotting range for the x axis.
+  `[0, 0]` stands for automatic.
 
-- **`width`** : Number of characters per row that should be used for plotting.
+- **`ylim`** : Plotting range for the y axis.
+  `[0, 0]` stands for automatic.
 
-- **`height`** : Number of rows that should be used for plotting. Not applicable to `barplot`.
-
-- **`border`** : The style of the bounding box of the plot. Supports `:solid`, `:bold`, `:dashed`, `:dotted`, `:ascii`, and `:none`.
-
-- **`xlim`** : Plotting range for the x coordinate. `[0, 0]` stands for automatic.
-
-- **`ylim`** : Plotting range for the y coordinate. `[0, 0]` stands for automatic.
-
-- **`margin`** : Number of empty characters to the left of the whole plot.
-
-- **`padding`** : Space of the left and right of the plot between the labels and the canvas.
-
-- **`labels`** : Can be used to hide the labels by setting `labels=false`.
-
-- **`grid`** : Can be used to hide the gridlines at the origin
+- **`grid`** : If `true`, draws grid-lines at the origin.
 
 Methods
 ========
@@ -71,7 +62,9 @@ Author(s)
 see also
 =========
 
-`scatterplot`, `lineplot`, `BarplotGraphics`, `BrailleCanvas`, `BlockCanvas`, `AsciiCanvas`
+[`scatterplot`](@ref), [`lineplot`](@ref),
+[`BarplotGraphics`](@ref), [`BrailleCanvas`](@ref),
+[`BlockCanvas`](@ref), [`AsciiCanvas`](@ref)
 """
 mutable struct Plot{T<:GraphicsArea}
     graphics::T
@@ -180,7 +173,7 @@ function next_color!(plot::Plot{<:GraphicsArea})
 end
 
 """
-`title(plot) →  String`
+    title(plot) -> String
 
 Returns the current title of the given plot.
 Alternatively, the title can be changed with `title!`.
@@ -190,7 +183,7 @@ function title(plot::Plot)
 end
 
 """
-`title!(plot, newtitle) →  Plot`
+    title!(plot, newtitle) -> plot
 
 Sets a new title for the given plot.
 Alternatively, the current title can be
@@ -202,7 +195,7 @@ function title!(plot::Plot, title::AbstractString)
 end
 
 """
-`xlabel(plot) →  String`
+    xlabel(plot) -> String
 
 Returns the current label for the x-axis.
 Alternatively, the x-label can be changed with `xlabel!`
@@ -212,7 +205,7 @@ function xlabel(plot::Plot)
 end
 
 """
-`xlabel!(plot, newlabel) →  Plot`
+    xlabel!(plot, newlabel) -> plot
 
 Sets a new x-label for the given plot.
 Alternatively, the current label can be
@@ -224,7 +217,7 @@ function xlabel!(plot::Plot, xlabel::AbstractString)
 end
 
 """
-`ylabel(plot) →  String`
+    ylabel(plot) -> String
 
 Returns the current label for the y-axis.
 Alternatively, the y-label can be changed with `ylabel!`
@@ -234,7 +227,7 @@ function ylabel(plot::Plot)
 end
 
 """
-`ylabel!(plot, newlabel) →  Plot`
+    ylabel!(plot, newlabel) -> plot
 
 Sets a new y-label for the given plot.
 Alternatively, the current label can be
@@ -246,9 +239,9 @@ function ylabel!(plot::Plot, ylabel::AbstractString)
 end
 
 """
-`annotate!(plot, where, value[, color])`
+    annotate!(plot, where, value, [color])
 
-`annotate!(plot, where, row, value[, color])`
+    annotate!(plot, where, row, value, [color])
 
 This method is responsible for the setting
 all the textual decorations of a plot.

--- a/test/tst_boxplot.jl
+++ b/test/tst_boxplot.jl
@@ -11,6 +11,12 @@
         @io2str(show(IOContext(::IO, :color=>true), p)),
         render = BeforeAfterFull()
     )
+    p = @inferred boxplot("series1", [1,2,3,4,5], title = "Test", xlim = (-1,8), color = :blue, width = 50, border = :solid, xlabel="foo")
+    @test_reference(
+        "references/boxplot/default_parameters.txt",
+        @io2str(show(IOContext(::IO, :color=>true), p)),
+        render = BeforeAfterFull()
+    )
     p = @inferred boxplot("series1", [1,2,3,4,5], title = "Test", xlim = [-1,8], color = :blue, width = 50, border = :solid, xlabel="foo")
     @test_reference(
         "references/boxplot/default_parameters.txt",
@@ -26,6 +32,12 @@ end
 
 @testset "scaling" begin
     for (i, max_x) in enumerate([5,6,10,20,40])
+        p = @inferred boxplot([1,2,3,4,5], xlim=(0,max_x))
+        @test_reference(
+            "references/boxplot/scale$i.txt",
+            @io2str(show(IOContext(::IO, :color=>true), p)),
+            render = BeforeAfterFull()
+        )
         p = @inferred boxplot([1,2,3,4,5], xlim=[0,max_x])
         @test_reference(
             "references/boxplot/scale$i.txt",

--- a/test/tst_lineplot.jl
+++ b/test/tst_lineplot.jl
@@ -119,6 +119,7 @@ end
 end
 
 @testset "functions" begin
+    @test_throws ArgumentError lineplot(sin, 1:.5:12, color=:blue, ylim=(-1.,1., 2.))
     @test_throws ArgumentError lineplot(sin, 1:.5:12, color=:blue, ylim=[-1.,1., 2.])
     p = @inferred lineplot(sin)
     @test_reference(
@@ -187,6 +188,12 @@ end
 
     @test_throws DimensionMismatch lineplot([sin, cos], -.5, 3, name = ["s", "c", "d"])
     @test_throws DimensionMismatch lineplot([sin, cos], -.5, 3, color = [:red])
+    p = @inferred lineplot([sin, cos], -.5, 3, name = ["s", "c"], color = [:red, :yellow], title = "Funs", ylabel = "f", xlabel = "num", xlim = (-.5, 2.5), ylim = (-.9, 1.2))
+    @test_reference(
+        "references/lineplot/sincos_parameters.txt",
+        @io2str(show(IOContext(::IO, :color=>true), p)),
+        render = BeforeAfterFull()
+    )
     p = @inferred lineplot([sin, cos], -.5, 3, name = ["s", "c"], color = [:red, :yellow], title = "Funs", ylabel = "f", xlabel = "num", xlim = [-.5, 2.5], ylim = [-.9, 1.2])
     @test_reference(
         "references/lineplot/sincos_parameters.txt",
@@ -196,6 +203,12 @@ end
 end
 
 @testset "keyword arguments" begin
+    p = @inferred lineplot(x, y, xlim = (-1.5, 3.5), ylim = (-5.5, 2.5))
+    @test_reference(
+        "references/lineplot/limits.txt",
+        @io2str(show(IOContext(::IO, :color=>true), p)),
+        render = BeforeAfterFull()
+    )
     p = @inferred lineplot(x, y, xlim = [-1.5, 3.5], ylim = [-5.5, 2.5])
     @test_reference(
         "references/lineplot/limits.txt",

--- a/test/tst_scatterplot.jl
+++ b/test/tst_scatterplot.jl
@@ -66,6 +66,12 @@ y = [2, 0, -5, 2, -5]
     )
     miny = -1.2796649117521434e218
     maxy = -miny
+    p = @inferred scatterplot([1],[miny],xlim=(1,1),ylim=(miny,maxy))
+    @test_reference(
+        "references/scatterplot/scale3.txt",
+        @io2str(show(IOContext(::IO, :color=>true), p)),
+        render = BeforeAfterFull()
+    )
     p = @inferred scatterplot([1],[miny],xlim=[1,1],ylim=[miny,maxy])
     @test_reference(
         "references/scatterplot/scale3.txt",
@@ -75,6 +81,12 @@ y = [2, 0, -5, 2, -5]
 end
 
 @testset "keyword arguments" begin
+    p = @inferred scatterplot(x, y, xlim = (-1.5, 3.5), ylim = (-5.5, 2.5))
+    @test_reference(
+        "references/scatterplot/limits.txt",
+        @io2str(show(IOContext(::IO, :color=>true), p)),
+        render = BeforeAfterFull()
+    )
     p = @inferred scatterplot(x, y, xlim = [-1.5, 3.5], ylim = [-5.5, 2.5])
     @test_reference(
         "references/scatterplot/limits.txt",


### PR DESCRIPTION
Allows the keyword parameters `xlim` and `ylim` to be tuples instead of vectors

```julia
scatterplot(randn(50), ylim = (-1, 1))
```

 closes #96 