### PR TITLE
added support for vectors containing NaN in lineplot

### DIFF
--- a/src/canvas.jl
+++ b/src/canvas.jl
@@ -85,6 +85,9 @@ end
 function lines!(c::Canvas, X::AbstractVector, Y::AbstractVector, color::Union{Int, Symbol})
     length(X) == length(Y) || throw(DimensionMismatch("X and Y must be the same length"))
     for i in 1:(length(X)-1)
+        if isnan(X[i]) || isnan(X[i+1]) || isnan(Y[i]) || isnan(Y[i+1])
+            continue
+        end
         lines!(c, X[i], Y[i], X[i+1], Y[i+1], color)
     end
     c

--- a/src/interface/lineplot.jl
+++ b/src/interface/lineplot.jl
@@ -101,7 +101,9 @@ function lineplot(
         color::Symbol = :auto,
         name = "",
         kw...)
-    new_plot = Plot(x, y, canvas; kw...)
+    idx = map(!isnan, x)
+    idx .&= map(!isnan, y)
+    new_plot = Plot(x[idx], y[idx], canvas; kw...)
     lineplot!(new_plot, x, y; color = color, name = name)
 end
 


### PR DESCRIPTION
Added a couple of lines which allows lineplot to work with vectors containing NaN values, e.g. 
![image](https://user-images.githubusercontent.com/2874223/97176953-5ef02480-179e-11eb-8f24-50c9abe4460c.png)
