### PR TITLE
Allow passing color = symbol, integer or tuple of RGB values

### DIFF
--- a/src/UnicodePlots.jl
+++ b/src/UnicodePlots.jl
@@ -1,6 +1,7 @@
 module UnicodePlots
 
 using Dates
+using Crayons
 using StatsBase: Histogram, fit, percentile
 using SparseArrays: AbstractSparseMatrix, findnz
 

--- a/src/canvas.jl
+++ b/src/canvas.jl
@@ -4,11 +4,11 @@ origin(c::Canvas) = (origin_x(c), origin_y(c))
 Base.size(c::Canvas) = (width(c), height(c))
 pixel_size(c::Canvas) = (pixel_width(c), pixel_height(c))
 
-function pixel!(c::Canvas, pixel_x::Integer, pixel_y::Integer; color::Union{Int, Symbol} = :normal)
+function pixel!(c::Canvas, pixel_x::Integer, pixel_y::Integer; color::UserColorType = :normal)
     pixel!(c, pixel_x, pixel_y, color)
 end
 
-function points!(c::Canvas, x::Number, y::Number, color::Union{Int, Symbol})
+function points!(c::Canvas, x::Number, y::Number, color::UserColorType)
     origin_x(c) <= x <= origin_x(c) + width(c) || return c
     origin_y(c) <= y <= origin_y(c) + height(c) || return c
     plot_offset_x = x - origin_x(c)
@@ -18,11 +18,11 @@ function points!(c::Canvas, x::Number, y::Number, color::Union{Int, Symbol})
     pixel!(c, floor(Int, pixel_x), floor(Int, pixel_y), color)
 end
 
-function points!(c::Canvas, x::Number, y::Number; color::Union{Int, Symbol} = :normal)
+function points!(c::Canvas, x::Number, y::Number; color::UserColorType = :normal)
     points!(c, x, y, color)
 end
 
-function points!(c::Canvas, X::AbstractVector, Y::AbstractVector, color::Union{Int, Symbol})
+function points!(c::Canvas, X::AbstractVector, Y::AbstractVector, color::UserColorType)
     length(X) == length(Y) || throw(DimensionMismatch("X and Y must be the same length"))
     for I in eachindex(X, Y)
         points!(c, X[I], Y[I], color)
@@ -30,7 +30,7 @@ function points!(c::Canvas, X::AbstractVector, Y::AbstractVector, color::Union{I
     c
 end
 
-function points!(c::Canvas, X::AbstractVector, Y::AbstractVector, color::AbstractVector{T}) where {T <: Union{Int, Symbol}}
+function points!(c::Canvas, X::AbstractVector, Y::AbstractVector, color::AbstractVector{T}) where {T <: UserColorType}
     (length(X) == length(color) && length(X) == length(Y)) || throw(DimensionMismatch("X, Y, and color must be the same length"))
     for i in 1:length(X)
         points!(c, X[i], Y[i], color[i])
@@ -38,12 +38,12 @@ function points!(c::Canvas, X::AbstractVector, Y::AbstractVector, color::Abstrac
     c
 end
 
-function points!(c::Canvas, X::AbstractVector, Y::AbstractVector; color::Union{Int, Symbol} = :normal)
+function points!(c::Canvas, X::AbstractVector, Y::AbstractVector; color::UserColorType = :normal)
     points!(c, X, Y, color)
 end
 
 # Implementation of the digital differential analyser (DDA)
-function lines!(c::Canvas, x1::Number, y1::Number, x2::Number, y2::Number, color::Union{Int, Symbol})
+function lines!(c::Canvas, x1::Number, y1::Number, x2::Number, y2::Number, color::UserColorType)
     if (x1 < origin_x(c) && x2 < origin_x(c)) ||
         (x1 > origin_x(c) + width(c) && x2 > origin_x(c) + width(c))
         return c
@@ -78,11 +78,11 @@ function lines!(c::Canvas, x1::Number, y1::Number, x2::Number, y2::Number, color
     c
 end
 
-function lines!(c::Canvas, x1::Number, y1::Number, x2::Number, y2::Number; color::Union{Int, Symbol} = :normal)
+function lines!(c::Canvas, x1::Number, y1::Number, x2::Number, y2::Number; color::UserColorType = :normal)
     lines!(c, x1, y1, x2, y2, color)
 end
 
-function lines!(c::Canvas, X::AbstractVector, Y::AbstractVector, color::Union{Int, Symbol})
+function lines!(c::Canvas, X::AbstractVector, Y::AbstractVector, color::UserColorType)
     length(X) == length(Y) || throw(DimensionMismatch("X and Y must be the same length"))
     for i in 1:(length(X)-1)
         if isnan(X[i]) || isnan(X[i+1]) || isnan(Y[i]) || isnan(Y[i+1])
@@ -93,7 +93,7 @@ function lines!(c::Canvas, X::AbstractVector, Y::AbstractVector, color::Union{In
     c
 end
 
-function lines!(c::Canvas, X::AbstractVector, Y::AbstractVector; color::Union{Int, Symbol} = :normal)
+function lines!(c::Canvas, X::AbstractVector, Y::AbstractVector; color::UserColorType = :normal)
     lines!(c, X, Y, color)
 end
 

--- a/src/canvas/asciicanvas.jl
+++ b/src/canvas/asciicanvas.jl
@@ -110,7 +110,7 @@ instead.
 """
 struct AsciiCanvas <: LookupCanvas
     grid::Array{UInt16,2}
-    colors::Array{UInt8,2}
+    colors::Array{ColorType,2}
     pixel_width::Int
     pixel_height::Int
     origin_x::Float64

--- a/src/canvas/blockcanvas.jl
+++ b/src/canvas/blockcanvas.jl
@@ -30,7 +30,7 @@ using binary operations.
 """
 struct BlockCanvas <: LookupCanvas
     grid::Array{UInt8,2}
-    colors::Array{UInt8,2}
+    colors::Array{ColorType,2}
     pixel_width::Int
     pixel_height::Int
     origin_x::Float64

--- a/src/canvas/braillecanvas.jl
+++ b/src/canvas/braillecanvas.jl
@@ -11,7 +11,7 @@ that can individually be manipulated using binary operations.
 """
 struct BrailleCanvas <: Canvas
     grid::Array{Char,2}
-    colors::Array{UInt8,2}
+    colors::Array{ColorType,2}
     pixel_width::Int
     pixel_height::Int
     origin_x::Float64
@@ -44,14 +44,14 @@ function BrailleCanvas(char_width::Int, char_height::Int;
     pixel_width = char_width * x_pixel_per_char(BrailleCanvas)
     pixel_height = char_height * y_pixel_per_char(BrailleCanvas)
     grid = fill(Char(0x2800), char_width, char_height)
-    colors = fill(0x00, char_width, char_height)
+    colors = fill(nothing, char_width, char_height)
     BrailleCanvas(grid, colors,
                   pixel_width, pixel_height,
                   Float64(origin_x), Float64(origin_y),
                   Float64(width), Float64(height))
 end
 
-function pixel!(c::BrailleCanvas, pixel_x::Int, pixel_y::Int, color::Symbol)
+function pixel!(c::BrailleCanvas, pixel_x::Int, pixel_y::Int, color::UserColorType)
     0 <= pixel_x <= c.pixel_width  || return c
     0 <= pixel_y <= c.pixel_height || return c
     pixel_x = pixel_x < c.pixel_width ? pixel_x : pixel_x - 1
@@ -66,7 +66,7 @@ function pixel!(c::BrailleCanvas, pixel_x::Int, pixel_y::Int, color::Symbol)
     char_y = floor(Int, pixel_y / c.pixel_height * ch) + 1
     char_y_off = (pixel_y % 4) + 1
     c.grid[char_x,char_y] = Char(UInt64(c.grid[char_x,char_y]) | UInt64(braille_signs[char_x_off, char_y_off]))
-    c.colors[char_x,char_y] = c.colors[char_x,char_y] | color_encode[color]
+    set_color!(c.colors, char_x, char_y, crayon_256_color(color))
     c
 end
 

--- a/src/canvas/densitycanvas.jl
+++ b/src/canvas/densitycanvas.jl
@@ -11,7 +11,7 @@ the canvas can thus draw the density of datapoints.
 """
 mutable struct DensityCanvas <: Canvas
     grid::Array{UInt,2}
-    colors::Array{UInt8,2}
+    colors::Array{ColorType,2}
     pixel_width::Int
     pixel_height::Int
     origin_x::Float64
@@ -45,7 +45,7 @@ function DensityCanvas(char_width::Int, char_height::Int;
     pixel_width = char_width * x_pixel_per_char(DensityCanvas)
     pixel_height = char_height * y_pixel_per_char(DensityCanvas)
     grid = fill(0, char_width, char_height)
-    colors = fill(0x00, char_width, char_height)
+    colors = fill(nothing, char_width, char_height)
     DensityCanvas(grid, colors,
                   pixel_width, pixel_height,
                   Float64(origin_x), Float64(origin_y),
@@ -53,7 +53,7 @@ function DensityCanvas(char_width::Int, char_height::Int;
                   1)
 end
 
-function pixel!(c::DensityCanvas, pixel_x::Int, pixel_y::Int, color::Symbol)
+function pixel!(c::DensityCanvas, pixel_x::Int, pixel_y::Int, color::UserColorType)
     0 <= pixel_x <= c.pixel_width || return c
     0 <= pixel_y <= c.pixel_height || return c
     pixel_x = pixel_x < c.pixel_width ? pixel_x : pixel_x - 1
@@ -63,7 +63,7 @@ function pixel!(c::DensityCanvas, pixel_x::Int, pixel_y::Int, color::Symbol)
     char_y = floor(Int, pixel_y / c.pixel_height * ch) + 1
     c.grid[char_x,char_y] += 1
     c.max_density = max(c.max_density, c.grid[char_x,char_y])
-    c.colors[char_x,char_y] = c.colors[char_x,char_y] | color_encode[color]
+    set_color!(c.colors, char_x, char_y, crayon_256_color(color))
     c
 end
 

--- a/src/canvas/dotcanvas.jl
+++ b/src/canvas/dotcanvas.jl
@@ -21,7 +21,7 @@ instead.
 """
 struct DotCanvas <: LookupCanvas
     grid::Array{UInt8,2}
-    colors::Array{UInt8,2}
+    colors::Array{ColorType,2}
     pixel_width::Int
     pixel_height::Int
     origin_x::Float64

--- a/src/canvas/heatmapcanvas.jl
+++ b/src/canvas/heatmapcanvas.jl
@@ -1,5 +1,3 @@
-using Crayons
-
 """
 The `HeatmapCanvas` is also Unicode-based.
 It has a half the resolution of the `BlockCanvas`.
@@ -8,7 +6,7 @@ into two pixels (top and bottom).
 """
 struct HeatmapCanvas <: LookupCanvas
     grid::Array{UInt8,2}
-    colors::Array{UInt8,2}
+    colors::Array{ColorType,2}
     pixel_width::Int
     pixel_height::Int
     origin_x::Float64
@@ -30,6 +28,8 @@ function HeatmapCanvas(args...; kwargs...)
     CreateLookupCanvas(HeatmapCanvas, args...; min_char_width=1, min_char_height=1, kwargs...)
 end
 
+_toCrayon(c) = c === nothing ? 0 : (c isa Unsigned ? Int(c) : c)
+
 function printrow(io::IO, c::HeatmapCanvas, row::Int)
     0 < row <= nrows(c) || throw(ArgumentError("Argument row out of bounds: $row"))
     y = 2*row
@@ -40,9 +40,9 @@ function printrow(io::IO, c::HeatmapCanvas, row::Int)
     iscolor = get(io, :color, false)
     for x in 1:ncols(c)
         if iscolor
-            fgcol = Int(colors(c)[x, y])
+            fgcol = _toCrayon(c.colors[x, y])
             if (y - 1) > 0
-                bgcol = Int(colors(c)[x, y - 1])
+                bgcol = _toCrayon(c.colors[x, y - 1])
                 print(io, Crayon(foreground=fgcol, background=bgcol), HALF_BLOCK)
             # for odd numbers of rows, only print the foreground for the top row
             else

--- a/src/canvas/lookupcanvas.jl
+++ b/src/canvas/lookupcanvas.jl
@@ -31,13 +31,13 @@ function CreateLookupCanvas(
     pixel_width  = char_width * x_pixel_per_char(T)
     pixel_height = char_height * y_pixel_per_char(T)
     grid   = fill(0x00, char_width, char_height)
-    colors = fill(0x00, char_width, char_height)
+    colors = fill(nothing, char_width, char_height)
     T(grid, colors, pixel_width, pixel_height,
       Float64(origin_x), Float64(origin_y),
       Float64(width), Float64(height))
 end
 
-function pixel!(c::T, pixel_x::Int, pixel_y::Int, color::Union{Int, Symbol}) where {T <: LookupCanvas}
+function pixel!(c::T, pixel_x::Int, pixel_y::Int, color::UserColorType) where {T <: LookupCanvas}
     0 <= pixel_x <= pixel_width(c) || return c
     0 <= pixel_y <= pixel_height(c) || return c
     pixel_x = pixel_x < pixel_width(c) ? pixel_x : pixel_x - 1
@@ -51,13 +51,9 @@ function pixel!(c::T, pixel_x::Int, pixel_y::Int, color::Union{Int, Symbol}) whe
     end
     char_y = floor(Int, pixel_y / pixel_height(c) * ch) + 1
     char_y_off = (pixel_y % y_pixel_per_char(T)) + 1
-    grid(c)[char_x, char_y] = grid(c)[char_x,char_y] | lookup_encode(c)[char_x_off, char_y_off]
-    if color isa Symbol
-        colors(c)[char_x, char_y] = colors(c)[char_x,char_y] | color_encode[color]
-    else
-        # don't attempt to blend colors if they have been explicitly specified
-        colors(c)[char_x, char_y] = color
-    end
+    grid(c)[char_x, char_y] |= lookup_encode(c)[char_x_off, char_y_off]
+    force = !(color isa Symbol)  # don't attempt to blend colors if they have been explicitly specified
+    set_color!(c.colors, char_x, char_y, crayon_256_color(color); force=force)
     c
 end
 

--- a/src/common.jl
+++ b/src/common.jl
@@ -20,7 +20,8 @@ const DOC_PLOT_PARAMS = """
 
 - **`color`** : Color of the drawing.
   Can be any of `:green`, `:blue`, `:red`, `:yellow`, `:cyan`,
-  `:magenta`, `:white`, `:normal`
+  `:magenta`, `:white`, `:normal`, an integer in the range [0; 255],
+  or a tuple of three integers (RGB components).
 
 - **`width`** : Number of characters per row that should be used
   for plotting.
@@ -153,25 +154,38 @@ bordermap[:dashed] = border_dashed
 bordermap[:dotted] = border_dotted
 bordermap[:ascii]  = border_ascii
 
-const color_cycle = [:green, :blue, :red, :magenta, :yellow, :cyan]
-const color_encode = Dict{Symbol,UInt8}()
-const color_decode = Dict{UInt8,Symbol}()
-color_encode[:normal]  = 0b000
-color_encode[:blue]    = 0b001
-color_encode[:red]     = 0b010
-color_encode[:magenta] = 0b011
-color_encode[:green]   = 0b100
-color_encode[:cyan]    = 0b101
-color_encode[:yellow]  = 0b110
-for k in keys(color_encode)
-    v = color_encode[k]
-    color_decode[v] = k
-end
-color_encode[:white] = 0b111
-color_decode[0b111]  = :white
+const UserColorType = Union{Integer,Symbol,NTuple{3,Integer}}
+const ColorType = Union{Nothing,UInt8}
 
-function print_color(color::UInt8, io::IO, args...)
-    col = color in keys(color_decode) ? color_decode[color] : Int(color)
-    str = string(args...)
-    printstyled(io, str; color = col)
+const color_cycle = [:green, :blue, :red, :magenta, :yellow, :cyan]
+
+function print_color(color::Union{Nothing,Integer,Symbol}, io::IO, args...)
+    col = if color === nothing
+        :normal
+    elseif color isa Symbol
+        color
+    else
+        Int(color)
+    end
+    printstyled(io, string(args...); color = col)
+end
+
+function crayon_256_color(color::UserColorType)::ColorType
+    color in (:normal, :default) && return nothing
+    ansicolor = Crayons._parse_color(color)
+    if ansicolor.style == Crayons.COLORS_16
+        return Crayons.val(ansicolor) % 60
+    elseif ansicolor.style == Crayons.COLORS_24BIT
+        return Crayons.val(Crayons.to_256_colors(ansicolor))
+    end
+    Crayons.val(ansicolor)
+end
+
+@inline function set_color!(colors::Array{ColorType,2}, x::Int, y::Int, color::ColorType; force::Bool=false)
+    if color === nothing || colors[x, y] === nothing || force
+        colors[x, y] = color
+    else
+        colors[x, y] |= color
+    end
+    nothing
 end

--- a/src/graphics/bargraphics.jl
+++ b/src/graphics/bargraphics.jl
@@ -1,6 +1,6 @@
 mutable struct BarplotGraphics{R<:Number} <: GraphicsArea
     bars::Vector{R}
-    color::Symbol
+    color::UserColorType
     char_width::Int
     max_freq::Number
     max_len::Int
@@ -10,7 +10,7 @@ mutable struct BarplotGraphics{R<:Number} <: GraphicsArea
     function BarplotGraphics(
             bars::AbstractVector{R},
             char_width::Int,
-            color::Symbol,
+            color::UserColorType,
             symb::Union{Char,String},
             transform) where {R}
         length(symb) == 1 || throw(ArgumentError("The symbol to print has to be a single character, got: \"" * symb * "\""))
@@ -29,7 +29,7 @@ function BarplotGraphics(
         bars::AbstractVector{R},
         char_width::Int,
         transform = identity;
-        color::Symbol = :green,
+        color::UserColorType = :green,
         symb = "■") where {R <: Number}
     BarplotGraphics(bars, char_width, color, symb, transform)
 end

--- a/src/graphics/boxgraphics.jl
+++ b/src/graphics/boxgraphics.jl
@@ -8,7 +8,7 @@ end
 
 mutable struct BoxplotGraphics{R<:Number} <: GraphicsArea
     data::Vector{FiveNumberSummary}
-    color::Symbol
+    color::UserColorType
     char_width::Int
     min_x::R
     max_x::R
@@ -16,7 +16,7 @@ mutable struct BoxplotGraphics{R<:Number} <: GraphicsArea
     function BoxplotGraphics{R}(
             data::AbstractVector{R},
             char_width::Int,
-            color::Symbol,
+            color::UserColorType,
             min_x::R,
             max_x::R) where R
         char_width = max(char_width, 10)
@@ -43,7 +43,7 @@ ncols(c::BoxplotGraphics) = c.char_width
 function BoxplotGraphics(
         data::AbstractVector{R},
         char_width::Int;
-        color::Symbol = :green,
+        color::UserColorType = :green,
         min_x::Number = minimum(data),
         max_x::Number = maximum(data)) where {R <: Number}
     BoxplotGraphics{R}(data, char_width, color, R(min_x), R(max_x))

--- a/src/interface/boxplot.jl
+++ b/src/interface/boxplot.jl
@@ -75,7 +75,7 @@ function boxplot(
         text::AbstractVector{<:AbstractString},
         data::AbstractVector{<:AbstractArray{<:Number}};
         border = :corners,
-        color::Symbol = :green,
+        color::UserColorType = :green,
         width::Int = 40,
         xlim = (0., 0.),
         kw...)

--- a/src/interface/densityplot.jl
+++ b/src/interface/densityplot.jl
@@ -85,7 +85,7 @@ See also
 function densityplot(
         x::AbstractVector,
         y::AbstractVector;
-        color::Symbol = :auto,
+        color::UserColorType = :auto,
         grid = false,
         name = "",
         kw...)

--- a/src/interface/lineplot.jl
+++ b/src/interface/lineplot.jl
@@ -98,7 +98,7 @@ function lineplot(
         x::AbstractVector,
         y::AbstractVector;
         canvas::Type = BrailleCanvas,
-        color::Symbol = :auto,
+        color::UserColorType = :auto,
         name = "",
         kw...)
     idx = map(!isnan, x)
@@ -115,7 +115,7 @@ function lineplot!(
         plot::Plot{<:Canvas},
         x::AbstractVector,
         y::AbstractVector;
-        color::Symbol = :auto,
+        color::UserColorType = :auto,
         name = "")
     color = color == :auto ? next_color!(plot) : color
     name == "" || annotate!(plot, :r, string(name), color)

--- a/src/interface/scatterplot.jl
+++ b/src/interface/scatterplot.jl
@@ -90,7 +90,7 @@ function scatterplot(
         x::AbstractVector,
         y::AbstractVector;
         canvas::Type = BrailleCanvas,
-        color::Symbol = :auto,
+        color::UserColorType = :auto,
         name = "",
         kw...)
     new_plot = Plot(x, y, canvas; kw...)
@@ -105,7 +105,7 @@ function scatterplot!(
         plot::Plot{<:Canvas},
         x::AbstractVector,
         y::AbstractVector;
-        color::Symbol = :auto,
+        color::UserColorType = :auto,
         name = "")
     color = (color == :auto) ? next_color!(plot) : color
     name == "" || annotate!(plot, :r, string(name), color)

--- a/src/interface/spy.jl
+++ b/src/interface/spy.jl
@@ -109,7 +109,7 @@ function spy(
         height::Int = 0,
         margin::Int  = 3,
         padding::Int = 1,
-        color::Symbol = :auto,
+        color::UserColorType = :auto,
         canvas::Type{T} = BrailleCanvas,
         kw...) where {T <: Canvas}
     if color == :automatic

--- a/src/plot.jl
+++ b/src/plot.jl
@@ -297,7 +297,7 @@ If `where` is either `:l`, or `:r`, then `row`
 can be between 1 and the number of character rows
 of the plots canvas.
 """
-function annotate!(plot::Plot, loc::Symbol, value::AbstractString, color::Symbol)
+function annotate!(plot::Plot, loc::Symbol, value::AbstractString, color::UserColorType)
     loc == :t || loc == :b || loc == :l || loc == :r || loc == :tl || loc == :tr || loc == :bl || loc == :br || throw(ArgumentError("Unknown location: try one of these :tl :t :tr :bl :b :br"))
     if loc == :l || loc == :r
         for row = 1:nrows(plot.graphics)
@@ -323,11 +323,11 @@ function annotate!(plot::Plot, loc::Symbol, value::AbstractString, color::Symbol
     plot
 end
 
-function annotate!(plot::Plot, loc::Symbol, value::AbstractString; color::Symbol=:normal)
+function annotate!(plot::Plot, loc::Symbol, value::AbstractString; color::UserColorType=:normal)
     annotate!(plot, loc, value, color)
 end
 
-function annotate!(plot::Plot, loc::Symbol, row::Int, value::AbstractString, color::Symbol)
+function annotate!(plot::Plot, loc::Symbol, row::Int, value::AbstractString, color::UserColorType)
     if loc == :l
         plot.labels_left[row] = value
         plot.colors_left[row] = color
@@ -340,7 +340,7 @@ function annotate!(plot::Plot, loc::Symbol, row::Int, value::AbstractString, col
     plot
 end
 
-function annotate!(plot::Plot, loc::Symbol, row::Int, value::AbstractString; color::Symbol=:normal)
+function annotate!(plot::Plot, loc::Symbol, row::Int, value::AbstractString; color::UserColorType=:normal)
     annotate!(plot, loc, row, value, color)
 end
 
@@ -368,12 +368,12 @@ function print_title(io::IO, padding::AbstractString, title::AbstractString; p_w
     end
 end
 
-function print_border_top(io::IO, padding::AbstractString, length::Int, border::Symbol = :solid, color::Symbol = :light_black)
+function print_border_top(io::IO, padding::AbstractString, length::Int, border::Symbol = :solid, color::UserColorType = :light_black)
     b = bordermap[border]
     border == :none || printstyled(io, padding, b[:tl], repeat(b[:t], length), b[:tr]; color = color)
 end
 
-function print_border_bottom(io::IO, padding::AbstractString, length::Int, border::Symbol = :solid, color::Symbol = :light_black)
+function print_border_bottom(io::IO, padding::AbstractString, length::Int, border::Symbol = :solid, color::UserColorType = :light_black)
     b = bordermap[border]
     border == :none || printstyled(io, padding, b[:bl], repeat(b[:b], length), b[:br]; color = color)
 end


### PR DESCRIPTION
Allow passing arbitrary colors, e.g.:

```julia
using UnicodePlots

lineplot([1, 2], color=:black)
lineplot([1, 2], color=(0, 100, 200))
lineplot([1, 2], color=255)
```

Needed for `Plots.jl`, since we use `RGB` values internally.
Uses [`Crayon`](https://github.com/KristofferC/Crayons.jl) for color conversion: I think this is appropriated, since `Crayon` is already a dependency, and its `ANSIColor` type is coherent with terminal color output.

With https://github.com/Evizero/UnicodePlots.jl/pull/136 applied, all tests pass with newly generated images:

```julia
Test Summary: | Pass  Total
tst_common.jl |  106    106
Test Summary:   | Pass  Total
tst_graphics.jl |   79     79
Test Summary: | Pass  Total
tst_canvas.jl |  140    140
Test Summary: | Pass  Total
tst_plot.jl   |   64     64
Test Summary:  | Pass  Total
tst_barplot.jl |   32     32
Test Summary:    | Pass  Total
tst_histogram.jl |   19     19
Test Summary:      | Pass  Total
tst_scatterplot.jl |   45     45
Test Summary:   | Pass  Total
tst_lineplot.jl |   79     79
Test Summary: | Pass  Total
tst_spy.jl    |   16     16
Test Summary:  | Pass  Total
tst_boxplot.jl |   20     20
Test Summary:  | Pass  Total
tst_heatmap.jl |   75     75
```

Fix https://github.com/Evizero/UnicodePlots.jl/issues/20.
Fix https://github.com/Evizero/UnicodePlots.jl/issues/58.